### PR TITLE
Fixed lint issues on Windows

### DIFF
--- a/frontend/.prettierrc.yml
+++ b/frontend/.prettierrc.yml
@@ -1,0 +1,1 @@
+endOfLine: auto


### PR DESCRIPTION
Set end of line flag to 'auto'
This fixes lint errors related to end of line