### PR TITLE
Positioning New Users in the Loop Based on Nearest Existing Participant

### DIFF
--- a/server/internal/controllers/chain.go
+++ b/server/internal/controllers/chain.go
@@ -11,6 +11,7 @@ import (
 	"github.com/the-clothing-loop/website/server/internal/app/goscope"
 	"github.com/the-clothing-loop/website/server/internal/models"
 	"github.com/the-clothing-loop/website/server/internal/views"
+	"github.com/the-clothing-loop/website/server/pkg/tsp"
 
 	"github.com/gin-gonic/gin"
 	uuid "github.com/satori/go.uuid"
@@ -480,6 +481,9 @@ UPDATE user_chains
 SET is_approved = TRUE, created_at = NOW()
 WHERE user_id = ? AND chain_id = ?
 	`, user.ID, chain.ID)
+
+	newRoute, _ := tsp.GetRouteOrderWithNewUser(chain.ID, user.ID, db)
+	chain.SetRouteOrderByUserUIDs(db, newRoute) // update the route order
 
 	if user.Email.Valid {
 		views.EmailAnAdminApprovedYourJoinRequest(c, user.Name, user.Email.String, chain.Name)

--- a/server/internal/controllers/chain.go
+++ b/server/internal/controllers/chain.go
@@ -482,7 +482,9 @@ SET is_approved = TRUE, created_at = NOW()
 WHERE user_id = ? AND chain_id = ?
 	`, user.ID, chain.ID)
 
-	newRoute, _ := tsp.GetRouteOrderWithNewUser(chain.ID, user.ID, db)
+	// Given a ChainID and the UID of the new user returns the list of UserUIDs of the chain considering the addition of the new user
+	cities := retrieveChainUsersAsTspCities(db, chain.ID)
+	newRoute, _ := tsp.RunAddOptimalOrderNewCity[string](cities, user.UID)
 	chain.SetRouteOrderByUserUIDs(db, newRoute) // update the route order
 
 	if user.Email.Valid {

--- a/server/internal/controllers/route.go
+++ b/server/internal/controllers/route.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/the-clothing-loop/website/server/internal/app/auth"
+	"github.com/the-clothing-loop/website/server/internal/app/goscope"
 	"github.com/the-clothing-loop/website/server/internal/models"
 	"github.com/the-clothing-loop/website/server/pkg/tsp"
+	"gorm.io/gorm"
 )
 
 func RouteOrderGet(c *gin.Context) {
@@ -75,15 +77,37 @@ func RouteOptimize(c *gin.Context) {
 		return
 	}
 
-	minimalCost, optimalPath := tsp.OptimizeRoute(chain.ID, db)
+	// Given a ChainUID return an optimized route for all the approved participant of the loop
+	// with latitude and longitude.
+	cities := retrieveChainUsersAsTspCities(db, chain.ID)
+	minimalCost, optimalPath := tsp.RunOptimizeRouteWithCitiesMST[string](cities)
 
-	result := struct {
-		MinimalCost float64  `json:"minimal_cost"`
-		OptimalPath []string `json:"optimal_path"`
-	}{
-		MinimalCost: minimalCost,
-		OptimalPath: optimalPath,
+	c.JSON(200, gin.H{
+		"minimal_cost": minimalCost,
+		"optimal_path": optimalPath,
+	})
+}
+
+func retrieveChainUsersAsTspCities(db *gorm.DB, ChainID uint) []tsp.City[string] {
+	allUserChains := &[]tsp.City[string]{}
+
+	err := db.Raw(`
+	SELECT
+		users.uid AS Key,
+		users.latitude AS Latitude,
+		users.longitude AS Longitude,
+		user_chains.route_order AS RouteOrder
+	FROM user_chains
+	LEFT JOIN users ON user_chains.user_id = users.id
+	WHERE user_chains.chain_id = ? 
+	AND users.is_email_verified = TRUE 
+	AND user_chains.is_approved = TRUE
+	AND users.latitude <> 0 AND users.longitude <> 0 
+	ORDER BY user_chains.route_order ASC`, ChainID).Scan(allUserChains).Error
+
+	if err != nil {
+		goscope.Log.Errorf("Unable to retrieve associations between a loop and its users: %v", err)
+		return nil
 	}
-
-	c.JSON(200, &result)
+	return *allUserChains
 }

--- a/server/pkg/tsp/calculate_distances.go
+++ b/server/pkg/tsp/calculate_distances.go
@@ -2,8 +2,8 @@ package tsp
 
 import "math"
 
-func createDistanceMatrix(users []UserChain) [][]float64 {
-	n := len(users)
+func (t *Tsp[K]) CreateDistanceMatrix() [][]float64 {
+	n := len(t.Cities)
 	matrix := make([][]float64, n)
 
 	for i := 0; i < n; i++ {
@@ -12,7 +12,7 @@ func createDistanceMatrix(users []UserChain) [][]float64 {
 
 	for i := 0; i < n; i++ {
 		for j := i; j < n; j++ {
-			distance := calculateDistance(users[i], users[j])
+			distance := calculateDistance(t.Cities[i].Latitude, t.Cities[i].Longitude, t.Cities[j].Latitude, t.Cities[j].Longitude)
 			matrix[i][j] = distance
 			matrix[j][i] = distance
 		}
@@ -20,12 +20,12 @@ func createDistanceMatrix(users []UserChain) [][]float64 {
 	return matrix
 }
 
-func calculateDistance(user1, user2 UserChain) float64 {
-	lat1 := user1.Latitude
-	lon1 := user1.Longitude
-	lat2 := user2.Latitude
-	lon2 := user2.Longitude
-
+func calculateDistance(
+	lat1,
+	lon1,
+	lat2,
+	lon2 float64,
+) float64 {
 	// Calculate distance using Haversine formula
 	dLat := toRadians(lat2 - lat1)
 	dLon := toRadians(lon2 - lon1)

--- a/server/pkg/tsp/calculate_distances_util.go
+++ b/server/pkg/tsp/calculate_distances_util.go
@@ -1,0 +1,41 @@
+package tsp
+
+import "math"
+
+func createDistanceMatrix(users []UserChain) [][]float64 {
+	n := len(users)
+	matrix := make([][]float64, n)
+
+	for i := 0; i < n; i++ {
+		matrix[i] = make([]float64, n)
+	}
+
+	for i := 0; i < n; i++ {
+		for j := i; j < n; j++ {
+			distance := calculateDistance(users[i], users[j])
+			matrix[i][j] = distance
+			matrix[j][i] = distance
+		}
+	}
+	return matrix
+}
+
+func calculateDistance(user1, user2 UserChain) float64 {
+	lat1 := user1.Latitude
+	lon1 := user1.Longitude
+	lat2 := user2.Latitude
+	lon2 := user2.Longitude
+
+	// Calculate distance using Haversine formula
+	dLat := toRadians(lat2 - lat1)
+	dLon := toRadians(lon2 - lon1)
+	a := math.Sin(dLat/2)*math.Sin(dLat/2) + math.Cos(toRadians(lat1))*math.Cos(toRadians(lat2))*math.Sin(dLon/2)*math.Sin(dLon/2)
+	c := 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+	distance := 6371 * c // Earth's radius in kilometers
+
+	return distance
+}
+
+func toRadians(degrees float64) float64 {
+	return degrees * math.Pi / 180
+}

--- a/server/pkg/tsp/mst.go
+++ b/server/pkg/tsp/mst.go
@@ -4,10 +4,7 @@ package tsp
 
 const INT_MAX = float64(1e9)
 
-type MST struct {
-}
-
-func (MST) optimizeRoute(matrix [][]float64) (float64, []int) {
+func OptimizeRouteMST(matrix [][]float64) (float64, []int) {
 	var n = len(matrix)
 
 	var rootNode int
@@ -27,7 +24,8 @@ func (MST) optimizeRoute(matrix [][]float64) (float64, []int) {
 	var path = []int{}
 	var cost = float64(0)
 
-	prim := func() {
+	// prim
+	{
 		var max float64
 		var record float64
 		var parent int
@@ -56,16 +54,7 @@ func (MST) optimizeRoute(matrix [][]float64) (float64, []int) {
 		}
 	}
 
-	var preorder func(index int)
-	preorder = func(index int) {
-		path = append(path, index)
-		for _, i := range tree[index] {
-			preorder(i)
-		}
-	}
-
-	prim()
-	preorder(rootNode)
+	preorder(&tree, &path, rootNode)
 	path = append(path, rootNode) // to create the cycle
 	for i := 0; i < len(path)-1; i++ {
 		src := path[i]
@@ -73,4 +62,11 @@ func (MST) optimizeRoute(matrix [][]float64) (float64, []int) {
 		cost = cost + matrix[src][dest]
 	}
 	return cost, path
+}
+
+func preorder(tree *[][]int, path *[]int, index int) {
+	*path = append(*path, index)
+	for _, i := range (*tree)[index] {
+		preorder(tree, path, i)
+	}
 }

--- a/server/pkg/tsp/mst_test.go
+++ b/server/pkg/tsp/mst_test.go
@@ -1,0 +1,18 @@
+package tsp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreorder(t *testing.T) {
+	tree := [][]int{{1}, {1, 2}, {1, 2, 3}, {4}}
+	path := []int{1, 2}
+	preorder(&tree, &path, 2)
+	assert.Equal(t, []int{1, 2}, path)
+}
+
+func TestToRadians(t *testing.T) {
+	assert.Equal(t, toRadians(90), 25)
+}

--- a/server/pkg/tsp/mst_test.go
+++ b/server/pkg/tsp/mst_test.go
@@ -1,18 +1,36 @@
 package tsp
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPreorder(t *testing.T) {
-	tree := [][]int{{1}, {1, 2}, {1, 2, 3}, {4}}
-	path := []int{1, 2}
-	preorder(&tree, &path, 2)
-	assert.Equal(t, []int{1, 2}, path)
+func TestToRadians(t *testing.T) {
+	// Decimal point accuracy
+	p := 1e6
+
+	radian := toRadians(360)
+	assert.Equal(t, math.Round(radian*p)/p, 6.283185)
 }
 
-func TestToRadians(t *testing.T) {
-	assert.Equal(t, toRadians(90), 25)
+func TestCalculateDistance(t *testing.T) {
+	// Paris: Lat: 48.8566° N, Long: 2.3522° E.
+	paris := City[string]{
+		Latitude:  48.8566,
+		Longitude: 2.3522,
+	}
+	// Krakow: Lat: 50.0647° N, Long: 19.9450° E.
+	krakow := City[string]{
+		Latitude:  50.0647,
+		Longitude: 19.9450,
+	}
+	expectedDistance := 1275.6
+
+	// Decimal point accuracy
+	p := 10.0
+
+	sut := calculateDistance(paris.Latitude, paris.Longitude, krakow.Latitude, krakow.Longitude)
+	assert.Equal(t, expectedDistance, math.Round(sut*p)/p)
 }

--- a/server/pkg/tsp/run.go
+++ b/server/pkg/tsp/run.go
@@ -1,0 +1,19 @@
+package tsp
+
+func RunOptimizeRouteWithCitiesMST[K ~int | string | uint](cities []City[K]) (orderedKeys []K, minimalCost float64) {
+	t := &Tsp[K]{
+		Cities: cities,
+	}
+	distanceMatrix := t.CreateDistanceMatrix()
+	minimalCost, optimalPath := OptimizeRouteMST(distanceMatrix)
+	// obtaining the key of the cities based in their index in the optimalPath
+	orderedKeys = t.SortCitiesByOptimalPath(optimalPath)
+	return orderedKeys, minimalCost
+}
+
+func RunAddOptimalOrderNewCity[K ~int | string | uint](cities []City[K], key K) (orderedKeys []K, newCityOptimalOrder int) {
+	t := &Tsp[K]{
+		Cities: cities,
+	}
+	return t.GetRouteOrderWithNewCity(key)
+}


### PR DESCRIPTION
Changes made in this PR:
- A new method has been added to calculate the optimal position for a new user based on the nearest existing participant's order.
- The method is called when a user is approved to join the loop.
-  Functions related to calculating distances have been moved to a new file.

Additional  Comments:
Currently, the optimal position is determined as the order of the nearest participant + 1. But it will be better after having the nearest participant have a way to evaluate if it will be better to place the new user before or after the nearest.

Related issue https://github.com/the-clothing-loop/website/issues/552