### PR TITLE
WIP UsersService

### DIFF
--- a/server/internal/app/auth/auth.go
+++ b/server/internal/app/auth/auth.go
@@ -123,8 +123,8 @@ func AuthenticateUserOfChain(c *gin.Context, db *gorm.DB, chainUID, userUID stri
 	}
 
 	// get user
-	userServices := services.NewUsersService(db)
-	exist, user, err := userServices.GetByUID(userUID, false)
+	usersService := services.NewUsersService(db)
+	exist, user, err := usersService.GetByUID(userUID, false)
 	if err == nil && user.ID != 0 {
 		err = user.AddUserChainsToObject(db)
 	}

--- a/server/internal/controllers/chain.go
+++ b/server/internal/controllers/chain.go
@@ -323,7 +323,7 @@ func ChainUpdate(c *gin.Context) {
 
 func ChainAddUser(c *gin.Context) {
 	db := getDB(c)
-	userServices := services.NewUsersService(db)
+	usersService := services.NewUsersService(db)
 
 	var body struct {
 		UserUID      string `json:"user_uid" binding:"required,uuid"`
@@ -349,7 +349,7 @@ func ChainAddUser(c *gin.Context) {
 		c.String(http.StatusConflict, "Loop is not open to new members")
 		return
 	}
-	exist, user, _ := userServices.GetByUID(body.UserUID, true)
+	exist, user, _ := usersService.GetByUID(body.UserUID, true)
 
 	if !exist {
 		c.String(http.StatusBadRequest, models.ErrUserNotFound.Error())
@@ -379,7 +379,7 @@ LIMIT 1
 		}
 
 		// find admin users related to the chain to email
-		results, err := userServices.GetAdminsByChain(chain.ID)
+		results, err := usersService.GetAdminsByChain(chain.ID)
 		if err != nil {
 			goscope.Log.Errorf("Error retrieving chain admins: %s", err)
 			c.String(http.StatusInternalServerError, "No admins exist for this loop")

--- a/server/internal/controllers/login.go
+++ b/server/internal/controllers/login.go
@@ -8,6 +8,7 @@ import (
 	"github.com/the-clothing-loop/website/server/internal/app/auth"
 	"github.com/the-clothing-loop/website/server/internal/app/goscope"
 	"github.com/the-clothing-loop/website/server/internal/models"
+	"github.com/the-clothing-loop/website/server/internal/services"
 	"github.com/the-clothing-loop/website/server/internal/views"
 
 	"github.com/gin-gonic/gin"
@@ -28,14 +29,9 @@ func LoginEmail(c *gin.Context) {
 	}
 
 	// make sure that this email exists in db
-	user := models.User{}
-	res := db.Raw(`
-SELECT *
-FROM users
-WHERE email = ?
-LIMIT 1
-	`, body.Email).Scan(&user)
-	if res.Error != nil || user.ID == 0 {
+	userServices := services.NewUsersService(db)
+	exist, user, err := userServices.GetByEmail(body.Email)
+	if err != nil && !exist {
 		c.String(http.StatusUnauthorized, "Email is not yet registered")
 		return
 	}

--- a/server/internal/controllers/login.go
+++ b/server/internal/controllers/login.go
@@ -29,8 +29,8 @@ func LoginEmail(c *gin.Context) {
 	}
 
 	// make sure that this email exists in db
-	userServices := services.NewUsersService(db)
-	exist, user, err := userServices.GetByEmail(body.Email)
+	usersService := services.NewUsersService(db)
+	exist, user, err := usersService.GetByEmail(body.Email)
 	if err != nil && !exist {
 		c.String(http.StatusUnauthorized, "Email is not yet registered")
 		return

--- a/server/internal/controllers/users.go
+++ b/server/internal/controllers/users.go
@@ -11,6 +11,7 @@ import (
 	"github.com/the-clothing-loop/website/server/internal/app/auth"
 	"github.com/the-clothing-loop/website/server/internal/app/goscope"
 	"github.com/the-clothing-loop/website/server/internal/models"
+	"github.com/the-clothing-loop/website/server/internal/services"
 	"gopkg.in/guregu/null.v3"
 	"gopkg.in/guregu/null.v3/zero"
 	"gorm.io/gorm"
@@ -63,16 +64,9 @@ func UserGet(c *gin.Context) {
 		return
 	}
 
-	user := &models.User{}
-	if query.UserUID != "" {
-		db.Raw(`
-SELECT users.*
-FROM users
-WHERE users.uid = ? AND is_email_verified = TRUE
-LIMIT 1
-		`, query.UserUID).First(user)
-	}
-	if user.ID == 0 {
+	userServices := services.NewUsersService(db)
+	exist, user, _ := userServices.GetByUID(query.UserUID, true)
+	if !exist {
 		c.String(http.StatusBadRequest, "User not found")
 		return
 	}

--- a/server/internal/controllers/users.go
+++ b/server/internal/controllers/users.go
@@ -64,8 +64,8 @@ func UserGet(c *gin.Context) {
 		return
 	}
 
-	userServices := services.NewUsersService(db)
-	exist, user, _ := userServices.GetByUID(query.UserUID, true)
+	usersService := services.NewUsersService(db)
+	exist, user, _ := usersService.GetByUID(query.UserUID, true)
 	if !exist {
 		c.String(http.StatusBadRequest, "User not found")
 		return

--- a/server/internal/services/users.go
+++ b/server/internal/services/users.go
@@ -1,0 +1,79 @@
+package services
+
+import (
+	"errors"
+
+	"github.com/the-clothing-loop/website/server/internal/models"
+	"gopkg.in/guregu/null.v3/zero"
+	"gorm.io/gorm"
+)
+
+type UserContactData struct {
+	Name  string
+	Email zero.String
+}
+
+// UsersService defines the methods for user-related operations.
+type UsersService interface {
+	GetByUID(userUID string, checkEmailVerification bool) (exist bool, user *models.User, err error)
+	GetByEmail(userEmail string) (exist bool, user *models.User, err error)
+	GetAdminsByChain(chainId uint) ([]UserContactData, error)
+}
+
+type usersService struct {
+	db *gorm.DB
+}
+
+func NewUsersService(db *gorm.DB) UsersService {
+	return &usersService{
+		db: db,
+	}
+}
+
+func (u *usersService) GetByUID(userUID string, checkEmailVerification bool) (exist bool, user *models.User, err error) {
+
+	if userUID == "" {
+		return false, user, errors.New("userUID is mandatory")
+	}
+
+	query := `SELECT users.* FROM users	WHERE users.uid = ?`
+	if checkEmailVerification {
+		query += ` AND is_email_verified = TRUE`
+	}
+	query += ` LIMIT 1`
+
+	return executeQuery(u.db, query, userUID)
+}
+
+func (u *usersService) GetByEmail(userEmail string) (exist bool, user *models.User, err error) {
+	if userEmail == "" {
+		return false, user, errors.New("email is mandatory")
+	}
+	query := `SELECT users.* FROM users	WHERE users.email = ? LIMIT 1`
+	return executeQuery(u.db, query, userEmail)
+}
+
+func executeQuery(db *gorm.DB, query string, values ...string) (exist bool, user *models.User, err error) {
+	user = &models.User{}
+	err = db.Raw(query, values).First(&user).Error
+	return user.ID != 0, user, err
+}
+
+func (u *usersService) GetAdminsByChain(chainId uint) ([]UserContactData, error) {
+	results := []UserContactData{}
+
+	err := u.db.Raw(`
+	SELECT users.name AS name, users.email AS email
+	FROM user_chains AS uc
+	LEFT JOIN users ON uc.user_id = users.id 
+	WHERE uc.chain_id = ?
+		AND uc.is_chain_admin = TRUE
+		AND users.is_email_verified = TRUE
+	`, chainId).Scan(&results).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/server/internal/tests/integration_tests/users_service_test.go
+++ b/server/internal/tests/integration_tests/users_service_test.go
@@ -1,0 +1,94 @@
+package integration_tests
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/the-clothing-loop/website/server/internal/models"
+	"github.com/the-clothing-loop/website/server/internal/services"
+	"github.com/the-clothing-loop/website/server/internal/tests/mocks"
+)
+
+type testData struct {
+	testName      string
+	email         string
+	user          *models.User
+	expectedExist bool
+	expectedError error
+}
+
+func TestUsersService(t *testing.T) {
+
+	usersService := services.NewUsersService(db)
+
+	chain, _, _ := mocks.MockChainAndUser(t, db, mocks.MockChainAndUserOptions{})
+	expectedUserExist, _ := mocks.MockUser(t, db, chain.ID, mocks.MockChainAndUserOptions{IsChainAdmin: true})
+	tests := []testData{
+		{
+			testName:      "User exist",
+			email:         expectedUserExist.Email.String,
+			user:          expectedUserExist,
+			expectedExist: true,
+			expectedError: nil,
+		},
+		{
+			testName:      "User not exist",
+			email:         "nonexistent@example.com",
+			user:          &models.User{UID: "nonExistentUID"},
+			expectedExist: false,
+			expectedError: errors.New("record not found"),
+		},
+	}
+
+	t.Run("TestGetByUID", func(t *testing.T) {
+		testsUID := append(tests, testData{
+			testName:      "It has error because uid is empty",
+			email:         "",
+			user:          &models.User{UID: ""},
+			expectedExist: false,
+			expectedError: errors.New("userUID is mandatory"),
+		})
+
+		for _, test := range testsUID {
+			t.Run(test.testName, func(t *testing.T) {
+				exist, actualUser, err := usersService.GetByUID(test.user.UID, true)
+				assert.Equal(t, test.expectedExist, exist)
+				assert.Equal(t, test.expectedError, err)
+
+				if test.expectedExist && test.expectedError == nil {
+					assert.Equal(t, test.user.ID, actualUser.ID)
+				}
+
+			})
+		}
+	})
+
+	t.Run("TestGetByEmail", func(t *testing.T) {
+		testsEmail := append(tests, testData{
+			testName:      "It has error because email is empty",
+			email:         "",
+			user:          &models.User{UID: ""},
+			expectedExist: false,
+			expectedError: errors.New("email is mandatory"),
+		})
+
+		for _, test := range testsEmail {
+			t.Run(test.testName, func(t *testing.T) {
+				exist, actualUser, err := usersService.GetByEmail(test.email)
+				assert.Equal(t, test.expectedExist, exist)
+				assert.Equal(t, test.expectedError, err)
+
+				if test.expectedExist && test.expectedError == nil {
+					assert.Equal(t, test.user.ID, actualUser.ID)
+				}
+			})
+		}
+	})
+
+	t.Run("TestGetAdminsByChain", func(t *testing.T) {
+		users, err := usersService.GetAdminsByChain(chain.ID)
+		assert.Equal(t, 1, len(users))
+		assert.Nil(t, err)
+	})
+}


### PR DESCRIPTION
The PR introduces an initial version of the usersService. The idea of this service is to consolidate user-related logic into a unified location. For the design of the service an interface is utilized, it will simplify the controller tests in the future.

There are some concerns to address yet:

 - At times, the complete User struct is required, whereas, in other scenarios, only specific fields are needed. I am looking for a solution to incorporate both possibilities without redundant code.

- To use the service in the controller, it is necessary to create an instance
```
usersService := services.NewUsersService(db)
```
We could use a Dependency Injection library to avoid this. But, at the moment creating the instance every time is not so demanding

Related Issue https://github.com/the-clothing-loop/website/issues/564