### PR TITLE
refactoring UserGetAllOfChain from users controller

### DIFF
--- a/server/internal/controllers/users.go
+++ b/server/internal/controllers/users.go
@@ -124,7 +124,7 @@ func UserGetAllOfChain(c *gin.Context) {
 				thisUserChains = append(thisUserChains, userChain)
 			}
 		}
-		(users)[i].Chains = thisUserChains
+		users[i].Chains = thisUserChains
 	}
 	// omit user data from participants
 	if !isAuthState3AdminChainUser {
@@ -191,10 +191,10 @@ WHERE uc.chain_id = ? AND bi.id IS NOT NULL
 			}
 			if isPrivate {
 				if !isChainAdmin {
-					(users)[i].Email = zero.StringFrom("***")
-					(users)[i].PhoneNumber = "***"
+					users[i].Email = zero.StringFrom("***")
+					users[i].PhoneNumber = "***"
 				}
-				(users)[i].Address = "***"
+				users[i].Address = "***"
 			}
 		}
 	}

--- a/server/internal/controllers/users.go
+++ b/server/internal/controllers/users.go
@@ -100,7 +100,7 @@ func UserGetAllOfChain(c *gin.Context) {
 
 	// retrieve user from query
 	tx := db.Begin()
-	allUserChains, err := models.UserChainGeDataByChain(tx, chain.ID)
+	allUserChains, err := models.UserChainGetIndirectByChain(tx, chain.ID)
 
 	if err != nil {
 		goscope.Log.Errorf("Unable to retrieve associations between a loop and its users: %v", err)

--- a/server/internal/models/user.go
+++ b/server/internal/models/user.go
@@ -164,7 +164,7 @@ func UserGetAdminsByChain(db *gorm.DB, chainId uint) ([]UserContactData, error) 
 	return results, nil
 }
 
-func UserGetAllUsersByChain(db *gorm.DB, chainId uint) ([]User, error) {
+func UserGetAllUsersByChain(db *gorm.DB, chainID uint) ([]User, error) {
 	results := []User{}
 
 	err := db.Raw(`
@@ -172,7 +172,7 @@ func UserGetAllUsersByChain(db *gorm.DB, chainId uint) ([]User, error) {
 	FROM users
 	LEFT JOIN user_chains ON user_chains.user_id = users.id 
 	WHERE user_chains.chain_id = ? AND users.is_email_verified = TRUE
-	`, chainId).Scan(&results).Error
+	`, chainID).Scan(&results).Error
 
 	if err != nil {
 		return nil, err

--- a/server/internal/models/user.go
+++ b/server/internal/models/user.go
@@ -163,3 +163,19 @@ func UserGetAdminsByChain(db *gorm.DB, chainId uint) ([]UserContactData, error) 
 	}
 	return results, nil
 }
+
+func UserGetAllUsersByChain(db *gorm.DB, chainId uint) ([]User, error) {
+	results := []User{}
+
+	err := db.Raw(`
+	SELECT users.*
+	FROM users
+	LEFT JOIN user_chains ON user_chains.user_id = users.id 
+	WHERE user_chains.chain_id = ? AND users.is_email_verified = TRUE
+	`, chainId).Scan(&results).Error
+
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/server/internal/models/user_chain.go
+++ b/server/internal/models/user_chain.go
@@ -87,3 +87,28 @@ DELETE FROM bulky_items WHERE user_chain_id IN (
 
 	return nil
 }
+
+func UserChainGeDataByChain(db *gorm.DB, chainId uint) ([]UserChain, error) {
+	results := []UserChain{}
+
+	err := db.Raw(`
+	SELECT
+		user_chains.id             AS id,
+		user_chains.chain_id       AS chain_id,
+		chains.uid                 AS chain_uid,
+		user_chains.user_id        AS user_id,
+		users.uid                  AS user_uid,
+		user_chains.is_chain_admin AS is_chain_admin,
+		user_chains.created_at     AS created_at,
+		user_chains.is_approved    AS is_approved
+	FROM user_chains
+	LEFT JOIN chains ON user_chains.chain_id = chains.id
+	LEFT JOIN users ON user_chains.user_id = users.id
+	WHERE chains.id = ?
+	`, chainId).Scan(&results).Error
+
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/server/internal/tests/integration_tests/modals_chain_user_e2e_test.go
+++ b/server/internal/tests/integration_tests/modals_chain_user_e2e_test.go
@@ -1,0 +1,25 @@
+//go:build !ci
+
+package integration_tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/the-clothing-loop/website/server/internal/models"
+	"github.com/the-clothing-loop/website/server/internal/tests/mocks"
+)
+
+func TestChainUsersService(t *testing.T) {
+	chain, _, _ := mocks.MockChainAndUser(t, db, mocks.MockChainAndUserOptions{})
+	mocks.MockUser(t, db, chain.ID, mocks.MockChainAndUserOptions{IsChainAdmin: true})
+	mocks.MockUser(t, db, chain.ID, mocks.MockChainAndUserOptions{})
+	mocks.MockUser(t, db, chain.ID, mocks.MockChainAndUserOptions{})
+	mocks.MockUser(t, db, chain.ID, mocks.MockChainAndUserOptions{})
+
+	t.Run("UserChainGeDataByChain", func(t *testing.T) {
+		chainUserData, err := models.UserChainGeDataByChain(db, chain.ID)
+		assert.Equal(t, 5, len(chainUserData))
+		assert.Nil(t, err)
+	})
+}

--- a/server/internal/tests/integration_tests/modals_chain_user_e2e_test.go
+++ b/server/internal/tests/integration_tests/modals_chain_user_e2e_test.go
@@ -17,8 +17,8 @@ func TestChainUsersService(t *testing.T) {
 	mocks.MockUser(t, db, chain.ID, mocks.MockChainAndUserOptions{})
 	mocks.MockUser(t, db, chain.ID, mocks.MockChainAndUserOptions{})
 
-	t.Run("UserChainGeDataByChain", func(t *testing.T) {
-		chainUserData, err := models.UserChainGeDataByChain(db, chain.ID)
+	t.Run("UserChainGetIndirectByChain", func(t *testing.T) {
+		chainUserData, err := models.UserChainGetIndirectByChain(db, chain.ID)
 		assert.Equal(t, 5, len(chainUserData))
 		assert.Nil(t, err)
 	})

--- a/server/internal/tests/integration_tests/modals_user_e2e_test.go
+++ b/server/internal/tests/integration_tests/modals_user_e2e_test.go
@@ -86,4 +86,13 @@ func TestUsersService(t *testing.T) {
 		assert.Equal(t, 1, len(users))
 		assert.Nil(t, err)
 	})
+
+	t.Run("TestGetAllUsersByChain", func(t *testing.T) {
+		// adding more users
+		mocks.MockUser(t, db, chain.ID, mocks.MockChainAndUserOptions{})
+		mocks.MockUser(t, db, chain.ID, mocks.MockChainAndUserOptions{})
+		users, err := models.UserGetAllUsersByChain(db, chain.ID)
+		assert.Equal(t, 4, len(users))
+		assert.Nil(t, err)
+	})
 }


### PR DESCRIPTION
This PR refactors the function ```UserGetAllOfChain``` of users controller, putting the DB calls in the users and user_chain models. 
Also, a minor change in the WHERE clause of the SQL query to retrieve the UserChain data was made. 

the change is
```
WHERE users.id IN (
	SELECT user_chains.user_id
	FROM user_chains
	LEFT JOIN chains ON chains.id = user_chains.chain_id
	WHERE chains.id = ?
)
```
by
```
WHERE chains.id = ?
```
