### PR TITLE
refactors sending emails to admins when a user joins a loop

### DIFF
--- a/server/internal/controllers/login.go
+++ b/server/internal/controllers/login.go
@@ -8,6 +8,7 @@ import (
 	"github.com/the-clothing-loop/website/server/internal/app/auth"
 	"github.com/the-clothing-loop/website/server/internal/app/goscope"
 	"github.com/the-clothing-loop/website/server/internal/models"
+	"github.com/the-clothing-loop/website/server/internal/services"
 	"github.com/the-clothing-loop/website/server/internal/views"
 
 	"github.com/gin-gonic/gin"
@@ -75,62 +76,35 @@ func LoginValidate(c *gin.Context) {
 		return
 	}
 
-	// email a participant joined the loop
-	chainIDs := []uint{}
-	for _, uc := range user.Chains {
-		if !uc.IsChainAdmin {
-			chainIDs = append(chainIDs, uc.ChainID)
-		}
-	}
-
-	var results []struct {
-		Name  string
-		Email zero.String
-		Chain string
-		I18n  string
-	}
-	err = db.Raw(`
-SELECT
- users.name AS name, 
- users.email AS email,
- chains.name AS chain,
- users.i18n AS i18n
-FROM user_chains
-LEFT JOIN users ON user_chains.user_id = users.id 
-LEFT JOIN chains ON chains.id = user_chains.chain_id
-WHERE user_chains.chain_id IN ?
-	AND user_chains.is_chain_admin = TRUE
-	`, chainIDs).Scan(&results).Error
-	if err != nil {
-		goscope.Log.Errorf("Unable to find associated loop admins: %v", err)
-		c.String(http.StatusInternalServerError, "Unable to find associated loop admins")
-		return
-	}
-
 	// Is the first time verifying the user account
 	if user.Email.Valid && !user.IsEmailVerified {
-		db.Exec(`
-UPDATE chains SET published = TRUE WHERE id IN (
-	SELECT chain_id FROM user_chains WHERE user_id = ? AND is_chain_admin = TRUE
-)
-		`, user.ID)
+
+		db.Exec(`UPDATE chains SET published = TRUE WHERE id IN (
+			SELECT chain_id FROM user_chains WHERE user_id = ? AND is_chain_admin = TRUE
+	   )`, user.ID)
 
 		// Reset joined-at time
 		db.Exec(`UPDATE user_chains SET created_at = NOW() WHERE user_id = ?`, user.ID)
 
-		for _, result := range results {
-			if result.Email.Valid {
-				go views.EmailSomeoneIsInterestedInJoiningYourLoop(db, result.I18n,
-					result.Email.String,
-					result.Name,
-					result.Chain,
-					user.Name,
-					user.Email.String,
-					user.PhoneNumber,
-					user.Address,
-					user.Sizes,
-				)
+		// email a participant joined the loop
+		chainIDs := []uint{}
+		for _, uc := range user.Chains {
+			if !uc.IsChainAdmin {
+				chainIDs = append(chainIDs, uc.ChainID)
 			}
+		}
+
+		if len(chainIDs) > 0 {
+			err = services.EmailLoopAdminsOnUserJoin(db, user, chainIDs...)
+			if err != nil {
+				goscope.Log.Errorf("Unable to send email to associated loop admins: %v", err)
+				c.String(http.StatusInternalServerError, "Unable to send email to associated loop admins")
+				return
+			}
+
+			chainNames, _ := models.ChainGetNamesByIDs(db, chainIDs)
+			go services.EmailYouSignedUpForLoop(db, user, chainNames...)
+
 		}
 	}
 	// re-add IsEmailVerified, see TokenVerify

--- a/server/internal/models/chain.go
+++ b/server/internal/models/chain.go
@@ -120,3 +120,24 @@ func (c *Chain) ClearAllLastNotifiedIsUnapprovedAt(db *gorm.DB) error {
 	WHERE chain_id = ?
 	`, c.ID).Error
 }
+
+func ChainGetNamesByIDs(db *gorm.DB, chainIDs []uint) ([]string, error) {
+
+	type aux struct {
+		Name string
+	}
+	results := []aux{}
+
+	query := `SELECT chains.name FROM chains WHERE id IN ?`
+	err := db.Raw(query, chainIDs).Find(&results).Error
+	if err != nil {
+		return nil, err
+	}
+
+	names := []string{}
+	for _, v := range results {
+		names = append(names, v.Name)
+	}
+
+	return names, nil
+}

--- a/server/internal/models/user.go
+++ b/server/internal/models/user.go
@@ -115,9 +115,10 @@ LIMIT 1
 }
 
 type UserContactData struct {
-	Name  string
-	Email zero.String
-	I18n  string
+	Name      string
+	Email     zero.String
+	I18n      string
+	ChainName string
 }
 
 // Expects the userUID not to be empty
@@ -149,13 +150,14 @@ func UserGetByEmail(db *gorm.DB, userEmail string) (*User, error) {
 	return user, nil
 }
 
-func UserGetAdminsByChain(db *gorm.DB, chainId uint) ([]UserContactData, error) {
+func UserGetAdminsByChain(db *gorm.DB, chainId ...uint) ([]UserContactData, error) {
 	results := []UserContactData{}
 	err := db.Raw(`
-	SELECT users.name AS name, users.email AS email, users.i18n AS i18n
+	SELECT users.name AS name, users.email AS email, users.i18n AS i18n, chains.name as chain_name
 	FROM user_chains AS uc
-	LEFT JOIN users ON uc.user_id = users.id 
-	WHERE uc.chain_id = ?
+	LEFT JOIN users ON uc.user_id = users.id
+	LEFT JOIN chains ON uc.chain_id = chains.id 
+	WHERE uc.chain_id IN ?
 		AND uc.is_chain_admin = TRUE
 		AND users.is_email_verified = TRUE
 	`, chainId).Scan(&results).Error

--- a/server/internal/services/email.go
+++ b/server/internal/services/email.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"fmt"
+
+	"github.com/the-clothing-loop/website/server/internal/app/goscope"
+	"github.com/the-clothing-loop/website/server/internal/models"
+	"github.com/the-clothing-loop/website/server/internal/views"
+	"gorm.io/gorm"
+)
+
+/*
+Given a user and a list of ChainIds, this method performs the following actions:
+- searchs all admin from the given chains
+- sends them an email with the new user's information.
+- Also, it sends an email to the user for every loop he intends to join.
+*/
+func EmailLoopAdminsOnUserJoin(db *gorm.DB, user *models.User, chainIds ...uint) error {
+
+	// find admin users related to the chain to email
+	results, err := models.UserGetAdminsByChain(db, chainIds...)
+	if err != nil {
+		return err
+	}
+
+	if len(results) == 0 {
+		goscope.Log.Errorf("Empty chain that is still public: ChainID: %d", chainIds)
+		return fmt.Errorf("No admins exist for this loop")
+	}
+
+	for _, result := range results {
+		if result.Email.Valid {
+			views.EmailSomeoneIsInterestedInJoiningYourLoop(db, result.I18n,
+				result.Email.String,
+				result.Name,
+				result.ChainName,
+				user.Name,
+				user.Email.String,
+				user.PhoneNumber,
+				user.Address,
+				user.Sizes,
+			)
+		}
+	}
+
+	return nil
+}
+
+func EmailYouSignedUpForLoop(db *gorm.DB, user *models.User, chainNames ...string) error {
+	for _, chainName := range chainNames {
+		views.EmailYouSignedUpForLoop(db, user.I18n, user.Name, user.Email.String, chainName)
+	}
+	return nil
+}

--- a/server/internal/tests/integration_tests/modals_chain_e2e_test.go
+++ b/server/internal/tests/integration_tests/modals_chain_e2e_test.go
@@ -1,0 +1,27 @@
+//go:build !ci
+
+package integration_tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/the-clothing-loop/website/server/internal/models"
+	"github.com/the-clothing-loop/website/server/internal/tests/mocks"
+)
+
+func TestChainModel(t *testing.T) {
+	chain, _, _ := mocks.MockChainAndUser(t, db, mocks.MockChainAndUserOptions{})
+	chain1, _, _ := mocks.MockChainAndUser(t, db, mocks.MockChainAndUserOptions{})
+
+	t.Run("ChainGetNamesByIDs", func(t *testing.T) {
+		chainIds := []uint{chain.ID, chain1.ID}
+
+		chainNames, err := models.ChainGetNamesByIDs(db, chainIds)
+		fmt.Println(chainIds, chainNames)
+		assert.Equal(t, chain.Name, chainNames[0])
+		assert.Equal(t, chain1.Name, chainNames[1])
+		assert.Nil(t, err)
+	})
+}

--- a/server/internal/views/email.go
+++ b/server/internal/views/email.go
@@ -536,7 +536,7 @@ func EmailYouSignedUpForLoop(db *gorm.DB, lng,
 	err := emailGenerateMessage(m, lng, "you_signed_up_for_loop", gin.H{
 		"Name":      name,
 		"ChainName": chainName,
-	})
+	}, chainName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR introduces the following changes:
1 - Creation of the Email Service with the following functions:

1.1 - **EmailLoopAdminsOnUserJoin**: Given a User and a list of chainIds, it sends an email to every admin of those loops.

1.2 - **EmailYouSignedUpForLoop**: Given a User and a list of chainNames, it sends a confirmation email to the User for every loop.

2 - Replacing the email-sending logic in the chain and login controllers with a service call.

Some questions I have related to the changes:

I had to remove the **go** keyword because I encountered an error in my local environment. Is there a way to check if there is a problem with my local setup so I can add it again? If it's a general problem, then I could look for another way to send the email asynchronously.
 
Related Issue: https://github.com/the-clothing-loop/website/issues/601
