### PR TITLE
Change visible participants in a loop

### DIFF
--- a/bruno/chain/update.bru
+++ b/bruno/chain/update.bru
@@ -13,6 +13,7 @@ patch {
 body:json {
   {
     "uid": "{{chainUID}}",
-    "description": "Changed description"
+    "description": "Changed description",
+    "route_privacy": 4
   }
 }

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -302,5 +302,10 @@
   "clickHereToRegister": "<1>Click here</1> to register",
   "clickHereToLogin": "<1>Click here</1> to login",
   "mustBeRegistered": "You must be registered to create an event",
-  "userExists": "User already exists"
+  "userExists": "User already exists",
+  "routePrivacy": "Route Privacy",
+  "routePrivacyInfo": "Defines the visibility of participants within a loop. Set to -1 to make all participants visible to each other",
+  "routePrivacyAllVisible": "All participants in the route are visible to one another.",
+  "routePrivacyNoneVisible": "Participants are not visible to each other in the route.",
+  "routePrivacyWithCount": "{{ count }} participants above and {{ count }} participants below are visible."
 }

--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -23,7 +23,7 @@ export interface RequestRegisterChain {
   open_to_new_members: boolean;
   sizes: Array<Sizes | string> | null;
   genders: Array<Sizes | string> | null;
-  route_privacy: number
+  route_privacy: number;
 }
 
 export function registerChainAdmin(

--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -23,6 +23,7 @@ export interface RequestRegisterChain {
   open_to_new_members: boolean;
   sizes: Array<Sizes | string> | null;
   genders: Array<Sizes | string> | null;
+  route_privacy: number
 }
 
 export function registerChainAdmin(

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -48,7 +48,7 @@ export interface Chain {
   rules_override?: string;
   total_members?: number;
   total_hosts?: number;
-  route_privacy: number
+  route_privacy: number;
 }
 
 export interface Event {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -48,6 +48,7 @@ export interface Chain {
   rules_override?: string;
   total_members?: number;
   total_hosts?: number;
+  route_privacy: number
 }
 
 export interface Event {

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -22,6 +22,7 @@ interface Props {
   onSubmit: (values: RegisterChainForm) => void;
   initialValues?: RegisterChainForm;
   showBack?: boolean;
+  showRoutePrivacyField?: boolean;
 }
 
 export type RegisterChainForm = Omit<
@@ -69,6 +70,7 @@ export default function ChainDetailsForm({
   onSubmit,
   initialValues,
   showBack,
+  showRoutePrivacyField,
 }: Props) {
   const { t } = useTranslation();
   const { addToastError } = useContext(ToastContext);
@@ -86,6 +88,7 @@ export default function ChainDetailsForm({
     sizes: [],
     longitude: 0,
     latitude: 0,
+    route_privacy: 2,
     ...initialValues,
   });
 
@@ -256,6 +259,20 @@ export default function ChainDetailsForm({
             step="0.1"
             info={t("decideOnTheAreaYourLoopWillBeActiveIn")}
           />
+
+          {showRoutePrivacyField && (
+            <TextForm
+              type="number"
+              required
+              label={t("routePrivacy")}
+              name="route_privacy"
+              value={values.route_privacy}
+              onChange={(e) => setValue("route_privacy", e.target.valueAsNumber) }
+              step="1"
+              min={-1}
+              info={t("routePrivacyInfo")}
+            />
+          )}
 
           <div className="form-control relative w-full mb-4">
             <PopoverOnHover

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -267,7 +267,9 @@ export default function ChainDetailsForm({
               label={t("routePrivacy")}
               name="route_privacy"
               value={values.route_privacy}
-              onChange={(e) => setValue("route_privacy", e.target.valueAsNumber) }
+              onChange={(e) =>
+                setValue("route_privacy", e.target.valueAsNumber)
+              }
               step="1"
               min={-1}
               info={t("routePrivacyInfo")}

--- a/frontend/src/pages/ChainEdit.tsx
+++ b/frontend/src/pages/ChainEdit.tsx
@@ -68,6 +68,7 @@ export default function ChainEdit() {
         <p className="text-sm mb-1">{t("clickToChangeLoopLocation")}</p>
         <ChainDetailsForm
           showBack
+          showRoutePrivacyField
           onSubmit={handleSubmit}
           initialValues={chain}
         />

--- a/frontend/src/pages/ChainMemberList.tsx
+++ b/frontend/src/pages/ChainMemberList.tsx
@@ -532,6 +532,21 @@ export default function ChainMemberList() {
                 <dd className="text-sm mb-1">
                   {t("peopleWithCount", { count: users.length })}
                 </dd>
+
+                {isUserAdmin && (
+                  <>
+                    <dt className="font-bold mb-2">{t("routePrivacy")}</dt>
+                    <dd className="text-sm mb-1">
+                      {chain.route_privacy === 0
+                        ? t("routePrivacyNoneVisible")
+                        : chain.route_privacy !== -1
+                        ? t("routePrivacyWithCount", {
+                            count: chain.route_privacy,
+                          })
+                        : t("routePrivacyAllVisible")}
+                    </dd>
+                  </>
+                )}
               </dl>
 
               {isUserAdmin || authUser?.is_root_admin ? (

--- a/server/internal/controllers/chain.go
+++ b/server/internal/controllers/chain.go
@@ -80,6 +80,7 @@ func ChainCreate(c *gin.Context) {
 				RouteOrder:   0,
 			},
 		},
+		RoutePrivacy: 2, // default route_privacy
 	}
 	if err := db.Create(&chain).Error; err != nil {
 		goscope.Log.Warningf("Unable to create chain: %v", err)
@@ -123,6 +124,7 @@ func ChainGet(c *gin.Context) {
 		"genders":             chain.Genders,
 		"published":           chain.Published,
 		"open_to_new_members": chain.OpenToNewMembers,
+		"route_privacy":       chain.RoutePrivacy,
 	}
 
 	if query.AddRules {
@@ -275,6 +277,7 @@ func ChainUpdate(c *gin.Context) {
 		Published        *bool     `json:"published,omitempty"`
 		OpenToNewMembers *bool     `json:"open_to_new_members,omitempty"`
 		Theme            *string   `json:"theme,omitempty"`
+		RoutePrivacy     *int      `json:"route_privacy"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.String(http.StatusBadRequest, err.Error())
@@ -340,6 +343,9 @@ func ChainUpdate(c *gin.Context) {
 	}
 	if body.Theme != nil {
 		valuesToUpdate["theme"] = *(body.Theme)
+	}
+	if body.RoutePrivacy != nil {
+		valuesToUpdate["route_privacy"] = *(body.RoutePrivacy)
 	}
 	err := db.Model(chain).Updates(valuesToUpdate).Error
 	if err != nil {

--- a/server/internal/models/chain.go
+++ b/server/internal/models/chain.go
@@ -34,6 +34,7 @@ type Chain struct {
 	UpdatedAt        time.Time
 	DeletedAt        zero.Time
 	Theme            string
+	RoutePrivacy     int
 }
 
 func (c *Chain) SetRouteOrderByUserUIDs(db *gorm.DB, userUIDs []string) error {


### PR DESCRIPTION
The following pull request adds the ```RoutePrivacy```  field to store the visibility settings for participants. When a loop is created, the default value is set to 2. Admins can modify this setting on the ChainEdit Page.

The logic associated with the fields is as follows:
-1: All participants are visible to others
0: None are visible
otherNumber: {{ otherNumber }} participants above and {{ otherNumber }} participants below are visible.

Related issue: https://github.com/the-clothing-loop/website/issues/634
