### PR TITLE
send email to admins when user leave the loop

### DIFF
--- a/server/internal/controllers/chain.go
+++ b/server/internal/controllers/chain.go
@@ -14,7 +14,6 @@ import (
 	"github.com/the-clothing-loop/website/server/internal/services"
 	"github.com/the-clothing-loop/website/server/internal/views"
 	"github.com/the-clothing-loop/website/server/pkg/tsp"
-	"gopkg.in/guregu/null.v3/zero"
 
 	"github.com/gin-gonic/gin"
 	uuid "github.com/satori/go.uuid"
@@ -549,12 +548,12 @@ func ChainRemoveUser(c *gin.Context) {
 	chain.ClearAllLastNotifiedIsUnapprovedAt(db)
 
 	// if the user is removed by an admin, do not send an email to this one
-	var excludedEmail zero.String
+	var excludedEmail string
 	if _, isChainAdmin := authUser.IsPartOfChain(chain.UID); isChainAdmin {
-		excludedEmail = authUser.Email
+		excludedEmail = authUser.Email.String
 	}
 	// send email to chain admins
-	services.EmailLoopAdminsOnUserLeft(db, user, chain.ID, excludedEmail)
+	services.EmailLoopAdminsOnUserLeft(db, user.Name, user.Email.String, excludedEmail, chain.ID)
 }
 
 func ChainApproveUser(c *gin.Context) {


### PR DESCRIPTION
Related issue: https://github.com/the-clothing-loop/website/issues/634

This PR adds the method to email admins when a user leaves the loop. There are some exceptions:
- An admin removes the user. The email is not sent to this admin, but the others are.
- An admin removed himself. The email is sent to the other admins

