### PR TITLE
[879] update readme links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Steps to make a contribution
 
-If you haven'd set up your local environment please follow [the directions](DOCKER_DEV_SETUP.md)
+If you haven'd set up your local environment please follow [these directions](DOCKER_DEV_SETUP.md).
 
 1. Ensure that there is no one already assigned to the task you want to work on.
 2. Pull from the `CollActionteam:main` branch, then create a new branch from it written in [kebab-case](https://betterprogramming.pub/string-case-styles-camel-pascal-snake-and-kebab-case-981407998841).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Steps to make a contribution
 
-If you haven'd set up your local environment please follow the direction in [ONBOARDING_DEVS.md](https://github.com/CollActionteam/clothing-loop/blob/main/ONBOARDING_DEVS.md)
+If you haven'd set up your local environment please follow [the directions](DOCKER_DEV_SETUP.md)
 
 1. Ensure that there is no one already assigned to the task you want to work on.
 2. Pull from the `CollActionteam:main` branch, then create a new branch from it written in [kebab-case](https://betterprogramming.pub/string-case-styles-camel-pascal-snake-and-kebab-case-981407998841).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Checkout these readmes for more in-depth documentation:
 - React Native App : [README.md](https://github.com/the-clothing-loop/app2/blob/main/README.md)
 - SQL scripts: [README.md](/server/sql/README.md)
 
-Here are some flow diagrams to demonstrate some complex logic [README.md](/server/docs/README.md)
+If you want to understand the logic flows in this application, head to [/docs](/server/docs) for a bunch of diagrams showing just that.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ https://crowdin.com/project/the-clothing-loop
 
 ## Developers getting started
 
-Go here to setup your computer to run this website locally and create contributions: [docker/dev/README.md](/docker/dev/README.md)
+Start with reading our [contribution guidlines](CONTRIBUTING.md)
+Then set up your computer to [run this website locally](DOCKER_DEV_SETUP.md)
 
 
 Old: ~~If you want to setup this website on a linux development machine you can use the following documentation: [INSTALL_LINUX.md](/INSTALL_LINUX.md)~~
@@ -36,4 +37,4 @@ Here are some flow diagrams to demonstrate some complex logic [README.md](/serve
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ https://crowdin.com/project/the-clothing-loop
 
 ## Developers getting started
 
-Start with reading our [contribution guidlines](CONTRIBUTING.md)
-Then set up your computer to [run this website locally](DOCKER_DEV_SETUP.md)
+Start with reading our [contribution guidlines](CONTRIBUTING.md).
+
+Then set up your computer to [run this website locally](DOCKER_DEV_SETUP.md).
 
 
 Old: ~~If you want to setup this website on a linux development machine you can use the following documentation: [INSTALL_LINUX.md](/INSTALL_LINUX.md)~~


### PR DESCRIPTION
Minor README updates, including
- replace broken links with working ones
- add link to license
- minor copy tweaks

Fix #879 