### PR TITLE
Map: border loops, list shadow, mobile filter, hide-closed toggle

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -141,6 +141,7 @@
   "submit": "Submit",
   "create": "Create",
   "search": "Search",
+  "hideClosedLoops": "Hide closed Loops",
   "noResultsFound": "No results found",
   "noLoopsFoundIn": "No Loops found in",
   "close": "Close",

--- a/frontend/src/components/react/components/FindChain/SearchBar.tsx
+++ b/frontend/src/components/react/components/FindChain/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useMemo, useRef, useState } from "react";
+import { type FormEvent, useRef, useState } from "react";
 
 import Geocoding, { type Estimate } from "../../pages/Geocoding";
 
@@ -25,6 +25,7 @@ export interface SearchValues {
   searchTerm: string;
   sizes: string[];
   genders: string[];
+  openToNewMembers: boolean;
 }
 
 interface Props {
@@ -51,6 +52,9 @@ export function toUrlSearchParams(
   for (const gender of search.genders) {
     queryParams.append("g", gender);
   }
+  if (search.openToNewMembers) {
+    queryParams.append("otnm", "1");
+  }
   return "?" + queryParams.toString();
 }
 type MSearchChain = Pick<
@@ -70,6 +74,7 @@ export default function SearchBar(props: Props) {
     searchTerm: "",
     sizes: [],
     genders: [],
+    openToNewMembers: false,
     ...props.initialValues,
   });
   let refSubmit = useRef<any>();
@@ -136,14 +141,6 @@ export default function SearchBar(props: Props) {
     props.onSearch(values, longLat);
   }
 
-  const emptyValues = useMemo(
-    () =>
-      Object.values(values).reduce((isEmpty, v) => {
-        return isEmpty ? v.length === 0 : false;
-      }, true),
-    [values],
-  );
-
   return (
     <form
       onSubmit={handleSubmit}
@@ -177,11 +174,7 @@ export default function SearchBar(props: Props) {
         />
       </label>
 
-      <div
-        className={`flex group-focus-within:flex ${
-          !emptyValues ? "" : "hidden md:flex"
-        }`}
-      >
+      <div className="flex flex-wrap items-center">
         <div className="flex">
           <div className="w-36 sm:w-48 pr-0 sm:pr-4">
             <CategoriesDropdown
@@ -201,6 +194,16 @@ export default function SearchBar(props: Props) {
             />
           </div>
         </div>
+
+        <label className="flex items-center cursor-pointer whitespace-nowrap px-2 py-2 sm:py-0 ltr:sm:mr-4 rtl:sm:ml-4">
+          <input
+            type="checkbox"
+            className="checkbox checkbox-sm ltr:mr-2 rtl:ml-2"
+            checked={values.openToNewMembers}
+            onChange={(e) => setValue("openToNewMembers", e.target.checked)}
+          />
+          <span className="text-sm">{t("hideClosedLoops")}</span>
+        </label>
 
         <button type="submit" className="grow btn btn-primary" ref={refSubmit}>
           <span className="hidden sm:inline">{t("search")}</span>

--- a/frontend/src/components/react/components/FindChain/Sidebar.tsx
+++ b/frontend/src/components/react/components/FindChain/Sidebar.tsx
@@ -165,6 +165,8 @@ export default function SideBar({
             />
           ))}
         </div>
+        {/* Bottom shadow to hint that the list is scrollable */}
+        <div className="sticky bottom-0 h-5 -mt-5 pointer-events-none bg-gradient-to-t from-black/25 to-transparent" />
       </form>
     </div>
   );

--- a/frontend/src/components/react/pages/FindChain.tsx
+++ b/frontend/src/components/react/pages/FindChain.tsx
@@ -78,10 +78,15 @@ function mapToGeoJSONChains(
 function createFilterFunc(
   genders: string[],
   sizes: string[],
+  openToNewMembers: boolean = false,
 ): (c: Chain) => boolean {
-  if (!sizes?.length && !genders?.length) return (_: Chain) => true;
+  if (!sizes?.length && !genders?.length && !openToNewMembers)
+    return (_: Chain) => true;
 
   return (c: Chain) => {
+    if (openToNewMembers && !c.open_to_new_members) {
+      return false;
+    }
     for (let g of genders) {
       if (!c.genders?.includes(g)) {
         return false;
@@ -111,6 +116,7 @@ export default function FindChain() {
     searchTerm: urlParams.get("q") || "",
     sizes: urlParams.getAll("s") || [],
     genders: urlParams.getAll("g") || [],
+    openToNewMembers: urlParams.get("otnm") === "1",
   };
 
   const chains = useStore($chains);
@@ -173,6 +179,7 @@ export default function FindChain() {
       const filterFunc = createFilterFunc(
         urlParams.getAll("g"),
         urlParams.getAll("s"),
+        urlParams.get("otnm") === "1",
       );
 
       _map.on("load", () => {
@@ -235,17 +242,9 @@ export default function FindChain() {
           source: "chains",
           filter: [">", ["zoom"], clusterMaxZoom],
           paint: {
-            "circle-color": [
-              "case",
-              ["==", ["feature-state", "clicked"], true],
-              ["rgba", 81, 141, 126, 0.4],
-              [
-                "case",
-                ["get", "open_to_new_members"],
-                ["rgba", 240, 196, 73, 0.4], // #f0c449
-                ["rgba", 0, 0, 0, 0.1],
-              ],
-            ],
+            // Border-only style: keep the fill transparent (features stay
+            // clickable) and carry the color on the stroke instead.
+            "circle-color": ["rgba", 0, 0, 0, 0],
             "circle-radius": [
               "interpolate",
               ["exponential", 2],
@@ -259,12 +258,12 @@ export default function FindChain() {
             "circle-stroke-color": [
               "case",
               ["==", ["feature-state", "clicked"], true],
-              ["rgba", 72, 128, 139, 0.4],
+              ["rgba", 72, 128, 139, 1],
               [
                 "case",
                 ["get", "open_to_new_members"],
-                ["rgba", 240, 196, 73, 0.4], // #f0c449
-                ["rgba", 0, 0, 0, 0.1],
+                ["rgba", 240, 196, 73, 1], // #f0c449
+                ["rgba", 0, 0, 0, 0.3],
               ],
             ],
           },
@@ -446,6 +445,7 @@ export default function FindChain() {
     const filterFunc = createFilterFunc(
       urlParams.getAll("g"),
       urlParams.getAll("s"),
+      urlParams.get("otnm") === "1",
     );
     let ans = visibleFeatures
       .sort((a, b) => {
@@ -482,7 +482,7 @@ export default function FindChain() {
     (map.getSource("chains") as mapboxgl.GeoJSONSource).setData(
       mapToGeoJSONChains(
         chains,
-        createFilterFunc(search.genders, search.sizes),
+        createFilterFunc(search.genders, search.sizes, search.openToNewMembers),
       ),
     );
 
@@ -556,7 +556,11 @@ export default function FindChain() {
     searchedValues
       ? chains
           .filter(
-            createFilterFunc(searchedValues.genders, searchedValues.sizes),
+            createFilterFunc(
+              searchedValues.genders,
+              searchedValues.sizes,
+              searchedValues.openToNewMembers,
+            ),
           )
           .filter((chain) => chain.published && chain.open_to_new_members)
           .map((chain) => ({

--- a/frontend/src/components/react/pages/FindChain.tsx
+++ b/frontend/src/components/react/pages/FindChain.tsx
@@ -242,8 +242,6 @@ export default function FindChain() {
           source: "chains",
           filter: [">", ["zoom"], clusterMaxZoom],
           paint: {
-            // Border-only style: keep the fill transparent (features stay
-            // clickable) and carry the color on the stroke instead.
             "circle-color": ["rgba", 0, 0, 0, 0],
             "circle-radius": [
               "interpolate",


### PR DESCRIPTION
## Summary
Four v5.1.0 map improvements on the Find-a-Loop page, all in the map/sidebar/search components.

- **#765** — chain circles now render as a **border** instead of a filled disc (fill transparent, color on a solid 2px stroke; semantics kept: yellow = open to new members, teal = clicked, grey = closed).
- **#766** — **bottom shadow** on the loop list to hint it's scrollable.
- **#767** — filter is now **always visible on mobile**; removed the focus-to-reveal (`group-focus-within`) behavior.
- **#923** — new **"Hide closed Loops"** filter toggle. Serialized to the URL as `otnm=1` so it's shareable/bookmarkable; filters client-side via the existing `createFilterFunc` path.

## Release note
Map filter: added a "Hide closed Loops" toggle, made loops render as outlines, and made the filter available on mobile.

## Testing
- `npx tsc` — clean
- `npm run lint:test` (astro check + Prettier) — 0 errors, formatting clean

⚠️ Not yet verified visually (needs a Mapbox token + API). Please eyeball the border weight (#765), gradient contrast (#766), and the toggle wrapping on a narrow screen (#767/#923) via `astro dev`.

Closes #765
Closes #766
Closes #767
Closes #923