### PR TITLE
Fix map not loading loops (load-event race)

### DIFF
--- a/frontend/src/components/react/pages/FindChain.tsx
+++ b/frontend/src/components/react/pages/FindChain.tsx
@@ -135,7 +135,6 @@ export default function FindChain() {
   const mapRef = useRef<any>();
 
   useEffect(() => {
-    console.log("MAPBOX_TOKEN", MAPBOX_TOKEN);
     if (!mapRef.current) return;
     const _center = [
       Number.parseFloat(urlParams.get("lo") || ""),
@@ -163,8 +162,16 @@ export default function FindChain() {
     setZoom(4);
 
     const clusterMaxZoom = 8;
-    chainGetAll({ filter_out_unpublished: true }).then((res) => {
-      const _chains = res.data;
+    const chainsReq = chainGetAll({ filter_out_unpublished: true });
+    _map.on("load", async () => {
+      let _chains: Chain[];
+      try {
+        _chains = (await chainsReq).data;
+      } catch (err) {
+        console.error("Failed to load loops for the map", err);
+        addToastError(t("genericError"), 500);
+        return;
+      }
 
       _map.on("zoomend", (e) => {
         setZoom(e.target.getZoom());
@@ -175,7 +182,7 @@ export default function FindChain() {
         urlParams.getAll("s"),
       );
 
-      _map.on("load", () => {
+      const addChainLayers = () => {
         _map.addSource("chains", {
           type: "geojson",
           data: mapToGeoJSONChains(_chains, filterFunc),
@@ -373,7 +380,9 @@ export default function FindChain() {
             }
           }
         });
-      });
+      };
+
+      addChainLayers();
       $chains.set(_chains);
     });
 


### PR DESCRIPTION
Closes #979

## Problem
On the Find-a-Loop map, the basemap renders but **no loops appear** — reliably on production, never on acceptance.

The chains source + circle layers were added only inside a `map.on("load", …)` handler that was registered *after* the awaited `chainGetAll()` request resolved. Mapbox's `load` event fires once and is not replayed to listeners added later. So it's a race between the map finishing loading and the chains request returning — and the winner is decided by payload size:

- **Acceptance:** 3 chains / ~943 B → data wins the race → loops render.
- **Production:** 1993 chains / ~963 KB → the map loads first, the `load` handler is attached too late → **blank map.**

Verified: prod `chain/all` is a clean 200 with all-valid coordinates, so this is purely a listener-registration timing bug, not bad data.

## Fix
- Register the `load` handler **synchronously** (before it can fire), and `await` the already-in-flight chains request *inside* it. This removes the race deterministically, regardless of payload size — no reliance on `map.loaded()`.
- Surface a failed chains request with a toast instead of a silently blank map.
- Remove a leftover `console.log` of the token.

## Testing
- `npx tsc` — clean
- `npm run lint:test` — 0 errors, Prettier clean

⚠️ Not yet verified visually. Recommended: reproduce locally by delaying the chains request (or running against prod data) so the map loads first — on `main` the map goes blank, on this branch loops render.